### PR TITLE
the value of least_score of GetNearNameColors should be set to 0.5

### DIFF
--- a/mplcolors.py
+++ b/mplcolors.py
@@ -218,7 +218,7 @@ def GetDecoString(message):
 	return line + "\n" + message.center(size) + "\n" + line + "\n"
 
 
-def GetNearNameColors( target, colors, least_score = 0.05 ):
+def GetNearNameColors( target, colors, least_score = 0.5 ):
 	"""
 	Get near name colors based on difflib.SequenceMatcher.
 
@@ -233,7 +233,6 @@ def GetNearNameColors( target, colors, least_score = 0.05 ):
 	near_name_colors = {}
 	for name, color in colors.items():
 		diff = difflib.SequenceMatcher(None, target, name).ratio()
-
 		if diff > least_score:
 			near_name_colors[name] = color
 
@@ -256,7 +255,6 @@ def SearchColors( target, colors = mcolors.CSS4_COLORS ):
 		print(GetDecoString( message ))
 
 		suggestions = GetNearNameColors(target, colors)
-		print(suggestions)
 		if suggestions:
 			print("Maybe...")
 			PrintColors( suggestions )


### PR DESCRIPTION
Hello.  Thank you for your recent PR approval.
Today, I suggest that the value of  `least_score` of `GetNearNameColors` be set to 0.5.

if `least_score` is 0.05, it means the colors suggested have more than 5 percent similarity to the target.
Before, `mplcolors -s greem` shows below suggestions.
![image](https://user-images.githubusercontent.com/68532606/141670876-cea16a98-eb63-4b53-877e-07ec72db4265.png)
I think the result is not natural, and that there are too many colors. For example, red is far away from greem.

Now, set its value 0.5 and `mplcolors -s greem` shows
![image](https://user-images.githubusercontent.com/68532606/141671095-517c2883-5c71-4c1e-8cc0-93de5d1495c1.png)
This result is natural. If `least_score` is bigger or small than 0.5, The suggestion colors are too many or a few;
If 0.4:
![image](https://user-images.githubusercontent.com/68532606/141671124-fb0f5c95-9bce-410a-93ff-43ea372b5a23.png)
If 0.6:
![image](https://user-images.githubusercontent.com/68532606/141671141-3e8fa807-957e-42a4-832b-79be2a5ea6a5.png)


Thus, `least_score = 0.5` is better than `least_score = 0.05` and may be best value.
Another idea about this value is that user can change this value from some setting file or, more simply, from command line argument. In either case, I think that the default value of `least_score` should be set 0.5.
 

Also, this PR includes deleting `print(suggestions)` in mplcolors.py at line 258.
 `suggestions` is `dict` object. Therefore simple print is not user friendly. I guessed this `print` was for debugging, so I deleted it.
If the result shows not only color names but also color codes, I think it is better to introduce another option argument and implement another function.

Thanks.